### PR TITLE
bugfix: apply error resources

### DIFF
--- a/src/spaceone/inventory/connector/personal_health_dashboard.py
+++ b/src/spaceone/inventory/connector/personal_health_dashboard.py
@@ -31,43 +31,21 @@ class PersonalHealthDashboardConnector(AWSConnector):
             if e.response['Error']['Code'] == 'SubscriptionRequiredException':
                 raise ERROR_SUBSCRIPTION_REQUIRED()
             else:
-                _LOGGER.info(e)
+                _LOGGER.error(e)
+                raise ERROR_AWS_BOTO_REQUEST(message=e)
 
         except Exception as e:
-            _LOGGER.info(f'Fail to describe events: {e}')
-            return []
+            _LOGGER.error(f'Fail to describe events: {e}')
+            raise ERROR_AWS_BOTO_REQUEST(message=e)
 
     def describe_event_details(self, event_arns):
         try:
             response = self.client.describe_event_details(eventArns=event_arns)
             return response.get('successfulSet', [])
 
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'SubscriptionRequiredException':
-                raise ERROR_SUBSCRIPTION_REQUIRED()
-            else:
-                _LOGGER.info(e)
-
         except Exception as e:
-            _LOGGER.info(f'Fail to describe event details: {e}')
-            return []
-
-    def describe_entity_aggregates(self, event_arn, **query):
-        query = self.generate_query(is_paginate=True, **query)
-
-        try:
-            response = self.client.describe_entity_aggregates(eventArns=event_arn, **query)
-            return response.get('events', [])
-
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'SubscriptionRequiredException':
-                raise ERROR_SUBSCRIPTION_REQUIRED()
-            else:
-                _LOGGER.info(e)
-
-        except Exception as e:
-            _LOGGER.info(f'Fail to describe entity aggregates: {e}')
-            return []
+            _LOGGER.error(f'Fail to describe event details: {e}')
+            raise ERROR_AWS_BOTO_REQUEST(message=e)
 
     def describe_affected_entities(self, **query):
         query = self.generate_query(is_paginate=True, **query)
@@ -82,12 +60,24 @@ class PersonalHealthDashboardConnector(AWSConnector):
 
             return entities
 
+        except Exception as e:
+            _LOGGER.error(f'Fail to describe affected entities: {e}')
+            raise ERROR_AWS_BOTO_REQUEST(message=e)
+
+    def describe_entity_aggregates(self, event_arn, **query):
+        query = self.generate_query(is_paginate=True, **query)
+
+        try:
+            response = self.client.describe_entity_aggregates(eventArns=event_arn, **query)
+            return response.get('events', [])
+
         except ClientError as e:
             if e.response['Error']['Code'] == 'SubscriptionRequiredException':
                 raise ERROR_SUBSCRIPTION_REQUIRED()
             else:
-                _LOGGER.info(e)
+                _LOGGER.error(e)
+                raise ERROR_AWS_BOTO_REQUEST(message=e)
 
         except Exception as e:
-            _LOGGER.info(f'Fail to describe affected entities: {e}')
-            return []
+            _LOGGER.error(f'Fail to describe entity aggregates: {e}')
+            raise ERROR_AWS_BOTO_REQUEST(message=e)

--- a/src/spaceone/inventory/error/custom.py
+++ b/src/spaceone/inventory/error/custom.py
@@ -15,3 +15,7 @@ class ERROR_INVALID_CREDENTIALS(ERROR_INVALID_ARGUMENT):
 
 class ERROR_SUBSCRIPTION_REQUIRED(ERROR_BASE):
     _message = 'Upgrade AWS support level(ex. Business, Enterprise)'
+
+
+class ERROR_AWS_BOTO_REQUEST(ERROR_BASE):
+    _message = 'AWS API Request Error. {message}'


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description

1. All errors that may occur in the manager are raised until events are executed for loop. 
(before line 59 in personal_health_dashboard_manager.py )

2. Replaced _LOGGER.info with _LOGGER.error at the point where the error occurs.

3. In the case of SubscriptionRequiredException, it is applied to the describe_events method, which is the part that calls the api for the first time. Also, describe_entity_aggregates is not used in current logic, so I left SubscriptionRequiredException as it is.